### PR TITLE
Fixed the default selection for the ComboBox

### DIFF
--- a/ViewModels/CityListViewModel.cs
+++ b/ViewModels/CityListViewModel.cs
@@ -45,7 +45,11 @@ namespace AvaloniaTest.ViewModels
             _cityCache.AddOrUpdate(cities);
 
             // This is to pre-fill the selection with a default to test the combobox
-            SelectedCountry = new Country { CountryId = 3, Name = "The Netherlands" };
+            SelectedCountry = countries.First(); 
+            
+            /* Original code:
+             * SelectedCountry = new Country { CountryId = 3, Name = "The Netherlands" };
+             * The ComboBox is bound to Countries, but here a new instance is assigned which is not part of the list */
 
             //Search logic
             Func<City, bool> cityFilter(Country country) => city =>


### PR DESCRIPTION
The ComboBox was bound to Countries but SelectedCountry
was assigned an instance that was not part of Countries.

The `SelectedItem` needs to be part of the collection to which the ComboBox is bound.